### PR TITLE
SW-512 fix messageing system

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -46,7 +46,7 @@
         "version_and_newer": null,
         "version_and_older": null,
         "not_first_run": false,
-        "ts_after": 0,
+        "ts_after": 1625090400,
         "ts_before": 0
       },
       "content": {


### PR DESCRIPTION
- don't show the testimonial message anymore as this is no longer valid
- the chosen timestamp is `Thursday, July 1, 2021 12:00:00 AM [GMT+02:00]`